### PR TITLE
Update.

### DIFF
--- a/mini_test/mini_test_himekuri.rb
+++ b/mini_test/mini_test_himekuri.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'time'
+require 'core'
+require 'minitest/autorun'
+
+# Mini_test file load.
+class HimekuriTest < Minitest::Test
+  def test_himekuri
+    # dotenv == string
+    @koyomi = CoreNYM.koyomi
+
+    dt = Time.new.getlocal('+09:00')
+    week = %w(日 月 火 水 木 金 土)[dt.wday]
+    @himekuri = "#{dt.year}年" + "#{dt.month}月" + "#{dt.day}日" + ' : '.to_s + "#{dt.hour}時"+"#{dt.min}分"+"#{dt.sec}秒" + ' : '.to_s + week + "曜日"
+
+    assert_equal(@koyomi, @himekuri)
+  end
+end


### PR DESCRIPTION
#### mini_test_pgversion.rb

> NameError: uninitialized constant CoreNYM::ActiveRecord

クラスを読み込めないため、単体テスト用ファイルの削除。

#### mini_test_gem_version.rb

```markdown
Run options: --seed 58872

# Running:



Finished in 0.002246s, 0.0000 runs/s, 0.0000 assertions/s.

0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
```

評価しないため、単体テスト用ファイルの削除。
